### PR TITLE
[FIX] getCurrentPosition으로 변경

### DIFF
--- a/src/components/common/GeolocationAPI.js
+++ b/src/components/common/GeolocationAPI.js
@@ -5,11 +5,8 @@ import Geolocation from '@react-native-community/geolocation';
  * @param setCoord 좌표를 설정하는 setState 함수
  */
 
-var watchId = null;
-
-export function watchPosition(setCoord) {
-  clearWatchPostiion();
-  watchId = Geolocation.watchPosition(
+export function getCurrentPosition(setCoord) {
+  Geolocation.getCurrentPosition(
     (info) => {
       const latitude = info.coords.latitude;
       const longitude = info.coords.longitude;
@@ -20,9 +17,4 @@ export function watchPosition(setCoord) {
     },
     { enableHighAccuracy: true }
   );
-}
-
-export function clearWatchPostiion() {
-  if (watchId != null) Geolocation.clearWatch(watchId);
-  watchId = null;
 }

--- a/src/screens/Home.js
+++ b/src/screens/Home.js
@@ -1,7 +1,7 @@
 import Container from '../components/common/Container';
 import DistanceButton from '../components/home/DistanceButton';
 import DistanceModal from '../components/home/DistanceModal';
-import { watchPosition } from '../components/common/GeolocationAPI';
+import { getCurrentPosition } from '../components/common/GeolocationAPI';
 import { useState } from 'react';
 
 const Home = () => {
@@ -14,7 +14,7 @@ const Home = () => {
       <DistanceButton
         minute={minute}
         onPress={() => {
-          watchPosition(setCoord);
+          getCurrentPosition(setCoord);
           setVisible(true);
         }}
       />


### PR DESCRIPTION
### ISSUE https://github.com/egomogo/front-end/issues/5

- watchPosition -> getCurrentPosition으로 변경함

- 차이점
    - watchPosition: 이거는 사용자가 움직이는 것을 **계속** 감시? 감지한다. 근대 이건 너무 정밀도가 높아진 기분이 들었다. 대가리 방향만 돌려도 이동이 된것으로 감지를 한다.
    - getCurrentPosition: 자신이 원할 때 **1회성**으로 GPS의 snapshot을 볼 수 있는 방법

[출처] <a href='https://tlqckd0.tistory.com/44'>React에서 GPS사용하기 watchPosition, getCurrentPosition 차이점</a>