### PR TITLE
[FEAT] Get category Axios

### DIFF
--- a/src/axios/category.js
+++ b/src/axios/category.js
@@ -1,0 +1,7 @@
+import request from './axios';
+import { GET_CATEGORY } from '../constants/api';
+
+export const getCategory = async () => {
+  return request.get(GET_CATEGORY());
+  //   return GET_CATEGORY();
+};

--- a/src/axios/category.js
+++ b/src/axios/category.js
@@ -1,7 +1,6 @@
 import request from './axios';
-import { GET_CATEGORY } from '../constants/api';
+import { GET_CATEGORY } from '../constants/API';
 
 export const getCategory = async () => {
   return request.get(GET_CATEGORY());
-  //   return GET_CATEGORY();
 };

--- a/src/axios/restaurant.js
+++ b/src/axios/restaurant.js
@@ -1,4 +1,4 @@
-import { GET_RANDOM_RESTAURANT } from '../constants/api';
+import { GET_RANDOM_RESTAURANT } from '../constants/API';
 import request from './axios';
 
 export const getRandomRestaurant = async (

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -9,3 +9,8 @@ export const GET_RANDOM_RESTAURANT = (
 ) => {
   return `/restaurants/random?seed=${seed}&category=${category}&x=${x}&y=${y}&distance_limit=${distanceLimit}&page=${page}&size=${size}`;
 };
+
+// category.js
+export const GET_CATEGORY = () => {
+  return `/restaurants/categories`;
+};

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -1,3 +1,4 @@
+// restaurant.js
 export const GET_RANDOM_RESTAURANT = (
   seed,
   category,

--- a/src/screens/RandomBox.js
+++ b/src/screens/RandomBox.js
@@ -4,7 +4,7 @@ import Container from '../components/common/Container';
 import RandomCard from '../components/randomBox/RandomCard';
 import Toast from '../components/common/Toast';
 import { NULL_DATA } from '../constants/Error';
-import { getRandomRestaurant } from '../axios/Random';
+import { getRandomRestaurant } from '../axios/restaurant';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { distanceLimitState, xState, yState } from '../atom';
 import HomeLogo from '../components/home/HomeLogo';
@@ -42,7 +42,7 @@ const RandomBox = ({ route, navigation }) => {
             text: NULL_DATA,
           });
         }
-        
+
         const updatedData = res.data.documents.map((item) => ({
           ...item,
           detail: false,


### PR DESCRIPTION
🚨**Merge 후 폴더명 api => API로 변경 필요**

category가 필요한 Screen에 다음 코드를 추가하면 사용할 수 있습니다. (아직 필터 부분 PR을 하지 않아서 적용 X)

```
useEffect(() => {
  getCategory()
    .then((res) => console.log(res.data))
    .catch((e) => console.log(e.response));
}, []);
```
결과
<img width="400" alt="image" src="https://github.com/egomogo/front-end/assets/78421872/b5981fd7-6de0-4d34-a67e-0addc6b4267e">
